### PR TITLE
Change google token provider name to "gcp"

### DIFF
--- a/apis/cluster/v1alpha1/cluster_user_auth_types.go
+++ b/apis/cluster/v1alpha1/cluster_user_auth_types.go
@@ -29,7 +29,7 @@ const (
 type TokenProviderName string
 
 const (
-	TokenProviderGoogle TokenProviderName = "google"
+	TokenProviderGoogle TokenProviderName = "gcp"
 	TokenProviderAWS    TokenProviderName = "aws"
 )
 


### PR DESCRIPTION
It's only needed in bytebuilders server for importing gke clusters

Signed-off-by: Masudur Rahman <masud@appscode.com>